### PR TITLE
feat: add windows support via .env file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+NODE_ENV=development

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
-node_modules
-dist
-build
+*.env
+
+dist/
+build/
+node_modules/

--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@
 
 ---
 
+> First Run
+
+```bash
+mv .env.example .env
+```
+
 > 启动测试：
 
 ```bash

--- a/package-lock.json
+++ b/package-lock.json
@@ -1934,6 +1934,24 @@
       "integrity": "sha1-rHTbC7qNM4CLvzaAnDpcNoNTFDY=",
       "dev": true
     },
+    "env-cmd": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/env-cmd/-/env-cmd-10.1.0.tgz",
+      "integrity": "sha512-mMdWTT9XKN7yNth/6N6g2GuKuJTsKMDHlQFUDacb/heQRRWOTIZ42t1rMHnQu4jYxU1ajdTeJM+9eEETlqToMA==",
+      "dev": true,
+      "requires": {
+        "commander": "^4.0.0",
+        "cross-spawn": "^7.0.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+          "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+          "dev": true
+        }
+      }
+    },
     "env-paths": {
       "version": "2.2.0",
       "resolved": "https://registry.npm.taobao.org/env-paths/download/env-paths-2.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "Robocat<neatfx@gmail.com>",
   "main": "./build/main.js",
   "scripts": {
-    "dev": "NODE_ENV=development node ./scripts/dev-runner.js",
+    "dev": "env-cmd node ./scripts/dev-runner.js",
     "dist": "node ./scripts/app-builder.js"
   },
   "dependencies": {
@@ -15,6 +15,7 @@
     "@vue/compiler-sfc": "^3.0.0-alpha.10",
     "electron": "^8.2.5",
     "electron-builder": "^22.6.0",
+    "env-cmd": "^10.1.0",
     "vite": "^0.15.1"
   }
 }


### PR DESCRIPTION
Hey,

I added a `.env` file and [`env-cmd`](https://www.npmjs.com/package/env-cmd) to enable windows support (windows does not handle environment variables well on it's own.

Also updated the README to include instructions, unfortunately I only speak English so feel free to give me the appropriate string and I can update.

Finally would like to help out with English documentation if needed.